### PR TITLE
Bump shadowjar plugin version and switch over to fully use path/nio

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     `maven-publish`
-    id ("com.github.johnrengelman.shadow") version "7.1.0"
+    id ("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
 group = "xyz.citywide.citystom"

--- a/src/main/java/org/labgames/nextlib/Extension.java
+++ b/src/main/java/org/labgames/nextlib/Extension.java
@@ -85,21 +85,22 @@ public abstract class Extension extends net.minestom.server.extensions.Extension
         Toml toml = new Toml(defaults);
         Path path = Path.of(String.valueOf(getDataDirectory()), "config.toml");
 
-        if(!Files.exists(path)) {
-            try {
-                byte[] bytes = configResource.readAllBytes();
+        try {
+            if(!Files.exists(path)) {
                 if(!Files.exists(getDataDirectory()))
                     Files.createDirectory(path);
                 Files.createFile(path);
                 OutputStream stream = Files.newOutputStream(path);
-                stream.write(bytes);
+                stream.write(configResource.readAllBytes());
+                configResource.close();
                 stream.close();
+                return toml;
+            } else {
                 configResource.close();
                 return toml.read(Files.newInputStream(path));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
             }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        return toml;
     }
 }


### PR DESCRIPTION
This PR bumps the version of the shadowjar plugin to the latest version and cleans up the getConfig() function.

It also switches over from using Java's old io to the nio package with the Files class and Paths.